### PR TITLE
Make changes to support continuous integration

### DIFF
--- a/TribeListSchema.js
+++ b/TribeListSchema.js
@@ -1,4 +1,3 @@
-var TribeListsSchema = mongoose.Schema({
-  TribeList_id: Number,
+var TribeListSchema = mongoose.Schema({
   songRefs: Array,
 });

--- a/app.json
+++ b/app.json
@@ -17,5 +17,15 @@
     {
       "url": "heroku/nodejs"
     }
-  ]
+  ],
+  "environments": {
+    "test": {
+      "env": {
+        "comment": "'env' is defined here to override the MONGODB_URI: true setting for Heroku CI test envioments.  I believe (unverified) the mongolab addon automatically sets this environment variable, but having it set to required=true causes Heroku to expect it to be preset via 'heroku config', which can't be done for heroku CI test apps."
+      },
+      "addons":[
+        "mongolab:sandbox"
+      ]
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "start": "nodemon server",
-    "test": "mocha test"
+    "test": "eslint . && mocha test"
   },
   "dependencies": {
     "angular": "^1.6.4",

--- a/test/server.spec.js
+++ b/test/server.spec.js
@@ -1,3 +1,4 @@
+const expect = require('chai').expect;
 const request = require('supertest');
 const server = require('../server/core');
 


### PR DESCRIPTION
This includes linting enforcement during CI builds.

One linting violation currently in the code is the "TribeList_id" field in the TribeList schema. MongoDB automatically includes a "_id" field in all collections, which follows a different convention than our linting style guide.  However, these _id fields do not need to be explicitly specified in the Mongoose schema (and probably shouldn't be, to avoid possibly naming-synchronization errors) in order to be used.  So we can address the linting issue by simply removing the field from the Mongoose schema.

In addition, renamed TribesListSchema to TribeListSchema to conform to the Mongoose convention of using singular nouns for schema names.